### PR TITLE
Implement token handling 

### DIFF
--- a/web/src/accounts/Accounts.js
+++ b/web/src/accounts/Accounts.js
@@ -14,10 +14,13 @@ class Accounts extends Component {
     state = { accounts: [] };
 
     componentWillMount = () => {
+        this.refresh();
+    }
+
+    refresh = () => {
         api.get('/v1/accounts')
-        .then(data => {
-            console.log(data);
-            this.setState({ accounts: data });
+        .then(response => {
+            this.setState({ accounts: response.data });
         }, error => {
             console.log('error!', error)
         });
@@ -25,12 +28,14 @@ class Accounts extends Component {
 
     render() {
         let classes = this.props.classes;
-
-        console.log(this.state.accounts);
+        let { accounts } = this.state;
 
         return (
             <div className={classes.root}>
-                Accounts
+                <h1>Accounts</h1>
+                <ul>
+                    {accounts.map(a => <li key={a.id}>{a.id + ' - ' + a.name + ' (' + a.role + ')'}</li>)}
+                </ul>
             </div>
         );
     }

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -28,6 +28,8 @@ api.interceptors.response.use(config => {
         let data = JSON.stringify(creds.refreshToken);
         let headers = { headers: { 'Content-Type': 'application/json' }};
 
+        // use 'axios' here instead of the 'api' instance we created to bypass our interceptors
+        // and avoid an endless loop should either of these two calls result in a 401.
         return axios.post('/v1/tokens/refresh', data, headers)
             .then(response => {
                 saveCredentials(response.data);


### PR DESCRIPTION
Added `api.js` which provides an instance of axios with request and response interceptors providing injection of access tokens (if one is present) and automatic refresh of access tokens on a 401 response.

Should a 401 response when refreshing result in an additional 401, credentials are cleared from local storage and the browser is navigated back to the application root, prompting a login.  This should only happen when a refresh token expires, and a new login is the desired behavior.