### PR TITLE
Return signed JWT from token refresh method

### DIFF
--- a/api/QCVOC.Api/Controllers/TokensController.cs
+++ b/api/QCVOC.Api/Controllers/TokensController.cs
@@ -137,14 +137,14 @@ namespace QCVOC.Api.Controllers
                 return BadRequest("The specified token is blank.");
             }
 
-            JwtSecurityToken refreshJwt;
+            JwtSecurityToken parsedRefreshJwt;
 
-            if (!TokenValidator.TryParseAndValidateToken(refreshToken, out refreshJwt))
+            if (!TokenValidator.TryParseAndValidateToken(refreshToken, out parsedRefreshJwt))
             {
                 return Unauthorized();
             }
 
-            var refreshTokenIdString = refreshJwt.Claims.Where(c => c.Type == "jti").FirstOrDefault()?.Value;
+            var refreshTokenIdString = parsedRefreshJwt.Claims.Where(c => c.Type == "jti").FirstOrDefault()?.Value;
 
             if (string.IsNullOrEmpty(refreshTokenIdString))
             {
@@ -173,6 +173,7 @@ namespace QCVOC.Api.Controllers
             }
 
             var accessJwt = TokenFactory.GetAccessToken(account, refreshTokenRecord.TokenId);
+            var refreshJwt = TokenFactory.GetRefreshToken(refreshTokenId, refreshTokenRecord.Expires, refreshTokenRecord.Issued);
             var response = new TokenResponse(accessJwt, refreshJwt);
 
             return Ok(response);

--- a/api/QCVOC.Api/Defaults.cs
+++ b/api/QCVOC.Api/Defaults.cs
@@ -8,7 +8,7 @@ namespace QCVOC.Api
     public static class Defaults
     {
         public static readonly string AppRoot = string.Empty;
-        public static readonly string DbConnectionString = "User ID=QCVOC;Password=QCVOC;Host=SQL;Port=5432;Database=QCVOC;Pooling = true;";
+        public static readonly string DbConnectionString = "User ID=test;Password=test;Host=SQL;Port=5432;Database=QCVOC;Pooling = true;";
         public static readonly int JwtAccessTokenExpiry = 30;
         public static readonly string JwtAudience = "QCVOC";
         public static readonly string JwtIssuer = "QCVOC";


### PR DESCRIPTION
The original implementation returned a parsed and validated JWT but it was unsigned due to having been parsed and then re-serialized.  This update discards the provided JWT and generates a new one from the token id and issued/expired dates from the database.

Closes #12 