### PR TITLE
Add PasswordResetRequired flag to Accounts

### DIFF
--- a/api/QCVOC.Api/Security/AccountFilters.cs
+++ b/api/QCVOC.Api/Security/AccountFilters.cs
@@ -26,6 +26,11 @@ namespace QCVOC.Api.Security
         public string Name { get; set; }
 
         /// <summary>
+        ///     Whether a password reset is required for the Account.
+        /// </summary>
+        public bool? PasswordResetRequired { get; set; }
+
+        /// <summary>
         ///     The Role by which to filter results.
         /// </summary>
         public Role? Role { get; set; }

--- a/api/QCVOC.Api/Security/Controller/SecurityController.cs
+++ b/api/QCVOC.Api/Security/Controller/SecurityController.cs
@@ -347,7 +347,7 @@ namespace QCVOC.Api.Security.Controller
 
             Account accountRecord;
 
-            if (User.GetId() != id && !User.IsInRole(nameof(Role.Administrator)))
+            if (User.GetId() == id && !User.IsInRole(nameof(Role.Administrator)))
             {
                 if (!string.IsNullOrWhiteSpace(account.Name) || account.Role != null)
                 {
@@ -423,7 +423,7 @@ namespace QCVOC.Api.Security.Controller
                     Role = account.Role ?? accountToUpdate.Role,
                     PasswordHash = account.Password == null ? accountToUpdate.PasswordHash :
                         Utility.ComputeSHA512Hash(account.Password),
-                    PasswordResetRequired = account.Password != null,
+                    PasswordResetRequired = User.GetId() != accountToUpdate.Id && account.Password != null,
                     CreationDate = accountToUpdate.CreationDate,
                     LastUpdateById = User.GetId(),
                     LastUpdateDate = DateTime.UtcNow,
@@ -506,6 +506,7 @@ namespace QCVOC.Api.Security.Controller
                 Id = account.Id,
                 Name = account.Name,
                 Role = account.Role,
+                PasswordResetRequired = account.PasswordResetRequired,
                 CreationDate = account.CreationDate,
                 LastUpdateDate = account.LastUpdateDate,
                 LastUpdateById = account.LastUpdateById,

--- a/api/QCVOC.Api/Security/Data/DTO/AccountResponse.cs
+++ b/api/QCVOC.Api/Security/Data/DTO/AccountResponse.cs
@@ -24,6 +24,11 @@ namespace QCVOC.Api.Security.Data.DTO
         public string Name { get; set; }
 
         /// <summary>
+        ///     Gets or sets a value indicating whether a password reset is required.
+        /// </summary>
+        public bool PasswordResetRequired { get; set; }
+
+        /// <summary>
         ///     Gets or sets the Role for the account.
         /// </summary>
         public Role Role { get; set; }

--- a/api/QCVOC.Api/Security/Data/DTO/TokenResponse.cs
+++ b/api/QCVOC.Api/Security/Data/DTO/TokenResponse.cs
@@ -45,6 +45,11 @@ namespace QCVOC.Api.Security.Data.DTO
         public DateTime Expires => AccessJwtSecurityToken.ValidTo;
 
         /// <summary>
+        ///     Gets the value of the NameIdentifier claim from the Access Token.
+        /// </summary>
+        public Guid Id => Guid.Parse(AccessJwtSecurityToken.Claims.Where(c => c.Type == ClaimTypes.NameIdentifier).SingleOrDefault().Value);
+
+        /// <summary>
         ///     Gets the time at which the Access Token was issued.
         /// </summary>
         public DateTime Issued => AccessJwtSecurityToken.ValidFrom;

--- a/api/QCVOC.Api/Security/Data/Model/Account.cs
+++ b/api/QCVOC.Api/Security/Data/Model/Account.cs
@@ -29,6 +29,11 @@ namespace QCVOC.Api.Security.Data.Model
         public string PasswordHash { get; set; }
 
         /// <summary>
+        ///     Gets or sets a value indicating whether a password reset is required.
+        /// </summary>
+        public bool PasswordResetRequired { get; set; }
+
+        /// <summary>
         ///     Gets or sets the Account Role.
         /// </summary>
         public Role Role { get; set; }
@@ -68,7 +73,11 @@ namespace QCVOC.Api.Security.Data.Model
             return this.Id == account.Id
             && this.Name == account.Name
             && this.PasswordHash == account.PasswordHash
-            && this.Role == account.Role;
+            && this.PasswordResetRequired == account.PasswordResetRequired
+            && this.Role == account.Role
+            && this.CreationDate == account.CreationDate
+            && this.LastUpdateDate == account.LastUpdateDate
+            && this.LastUpdateById == account.LastUpdateById;
         }
     }
 }

--- a/api/QCVOC.Api/Security/Data/Repository/AccountRepository.cs
+++ b/api/QCVOC.Api/Security/Data/Repository/AccountRepository.cs
@@ -41,9 +41,9 @@ namespace QCVOC.Api.Security.Data.Repository
 
             var query = builder.AddTemplate(@"
                 INSERT INTO accounts
-                    (id, name, passwordhash, role, creationdate, lastupdatedate, lastupdatebyid)
+                    (id, name, passwordhash, passwordresetrequired, role, creationdate, lastupdatedate, lastupdatebyid)
                 VALUES
-                    (@id, @name, @passwordhash, @role, @creationdate, @lastupdatedate, @lastupdatebyid);
+                    (@id, @name, @passwordhash, @passwordresetrequired, @role, @creationdate, @lastupdatedate, @lastupdatebyid);
             ");
 
             builder.AddParameters(new
@@ -51,6 +51,7 @@ namespace QCVOC.Api.Security.Data.Repository
                 id = account.Id,
                 name = account.Name,
                 passwordhash = account.PasswordHash,
+                passwordresetrequired = account.PasswordResetRequired,
                 role = account.Role,
                 creationdate = account.CreationDate,
                 lastupdatedate = account.LastUpdateDate,
@@ -120,6 +121,7 @@ namespace QCVOC.Api.Security.Data.Repository
                     a1.id,
                     a1.name,
                     a1.passwordhash,
+                    a1.passwordresetrequired,
                     a1.role,
                     a1.creationdate,
                     a1.lastupdatedate,
@@ -154,6 +156,11 @@ namespace QCVOC.Api.Security.Data.Repository
                 if (accountFilters.Id != null)
                 {
                     builder.Where("a1.id = @id", new { accountFilters.Id });
+                }
+
+                if (accountFilters.PasswordResetRequired != null)
+                {
+                    builder.Where("a1.passwordresetrequired = @passwordresetrequired", new { accountFilters.PasswordResetRequired });
                 }
 
                 if (accountFilters.CreationDateStart != null && accountFilters.CreationDateStart != null)
@@ -197,6 +204,7 @@ namespace QCVOC.Api.Security.Data.Repository
                 SET 
                     name = @name,
                     passwordhash = @passwordhash,
+                    passwordresetrequired = @passwordresetrequired,
                     role = @role,
                     lastupdatedate = @lastupdatedate,
                     lastupdatebyid = @lastupdatebyid
@@ -207,6 +215,7 @@ namespace QCVOC.Api.Security.Data.Repository
             {
                 name = account.Name,
                 passwordhash = account.PasswordHash,
+                passwordresetrequired = account.PasswordResetRequired,
                 role = account.Role,
                 id = account.Id,
                 lastupdatedate = account.LastUpdateDate,

--- a/api/QCVOC.Api/Security/TokenFactory.cs
+++ b/api/QCVOC.Api/Security/TokenFactory.cs
@@ -34,6 +34,7 @@ namespace QCVOC.Api.Security
             var claims = new Claim[]
             {
                 new Claim(ClaimTypes.Name, account.Name),
+                new Claim(ClaimTypes.NameIdentifier, account.Id.ToString()),
                 new Claim(ClaimTypes.Role, account.Role.ToString()),
                 new Claim("sub", account.Id.ToString()),
                 new Claim("name", account.Name),


### PR DESCRIPTION
The flag is set when the account is created and when reset by a user other than the owner.  This is to enforce secret passwords.