### PR TITLE
Prevent supervisors from creating Accounts not in the User role

### DIFF
--- a/api/QCVOC.Api/Security/Controller/SecurityController.cs
+++ b/api/QCVOC.Api/Security/Controller/SecurityController.cs
@@ -279,7 +279,7 @@ namespace QCVOC.Api.Security.Controller
                 return StatusCode(403, "Neither administrative nor supervisory accounts may be created by non-Administrative users.");
             }
 
-            if (AccountNameExists(account.Name)
+            if (AccountNameExists(account.Name))
             {
                 return Conflict($"A user named '{account.Name}' already exists.");
             }
@@ -385,14 +385,9 @@ namespace QCVOC.Api.Security.Controller
                     return StatusCode(403, "Supervisors may not modify administrative or supervisory Accounts.");
                 }
 
-                if (!string.IsNullOrWhiteSpace(account.Name))
+                if (AccountNameExistsExcludingId(account.Name, id))
                 {
-                    var conflictingAccounts = AccountRepository.GetAll(new AccountFilters() { Name = account.Name });
-
-                    if (conflictingAccounts.Any(a => a.Id != id))
-                    {
-                        return Conflict($"A user named '{account.Name}' already exists.");
-                    }
+                    return Conflict($"A user named '{account.Name}' already exists.");
                 }
 
                 accountRecord = new Account()

--- a/api/QCVOC.Api/Security/Controller/SecurityController.cs
+++ b/api/QCVOC.Api/Security/Controller/SecurityController.cs
@@ -538,7 +538,12 @@ namespace QCVOC.Api.Security.Controller
             }
         }
 
-        private bool AccountNameExistsExcludingId(string name, Guid id) 
+        private bool AccountNameExists(string name)
+        {
+            return AccountRepository.GetAll(new AccountFilters() { Name = name }).Any();
+        }
+
+        private bool AccountNameExistsExcludingId(string name, Guid id)
         {
             return AccountRepository.GetAll(new AccountFilters() { Name = name }).Any(a => a.Id != id);
         }

--- a/api/QCVOC.Api/Security/Controller/SecurityController.cs
+++ b/api/QCVOC.Api/Security/Controller/SecurityController.cs
@@ -397,7 +397,7 @@ namespace QCVOC.Api.Security.Controller
                     Role = accountToUpdate.Role,
                     PasswordHash = account.Password == null ? accountToUpdate.PasswordHash :
                         Utility.ComputeSHA512Hash(account.Password),
-                    PasswordResetRequired = User.GetId() != accountToUpdate.Id && account.Password != null,
+                    PasswordResetRequired = account.Password != null,
                     CreationDate = accountToUpdate.CreationDate,
                     LastUpdateById = User.GetId(),
                     LastUpdateDate = DateTime.UtcNow,
@@ -533,11 +533,21 @@ namespace QCVOC.Api.Security.Controller
 
         private bool AccountNameExists(string name)
         {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
             return AccountRepository.GetAll(new AccountFilters() { Name = name }).Any();
         }
 
         private bool AccountNameExistsExcludingId(string name, Guid id)
         {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
             return AccountRepository.GetAll(new AccountFilters() { Name = name }).Any(a => a.Id != id);
         }
     }

--- a/api/QCVOC.Api/Security/Controller/SecurityController.cs
+++ b/api/QCVOC.Api/Security/Controller/SecurityController.cs
@@ -279,9 +279,7 @@ namespace QCVOC.Api.Security.Controller
                 return StatusCode(403, "Neither administrative nor supervisory accounts may be created by non-Administrative users.");
             }
 
-            var existingAccount = AccountRepository.GetAll(new AccountFilters() { Name = account.Name }).FirstOrDefault();
-
-            if (existingAccount != default(Account))
+            if (AccountNameExists(account.Name)
             {
                 return Conflict($"A user named '{account.Name}' already exists.");
             }

--- a/api/QCVOC.Api/Security/Controller/SecurityController.cs
+++ b/api/QCVOC.Api/Security/Controller/SecurityController.cs
@@ -274,9 +274,9 @@ namespace QCVOC.Api.Security.Controller
                 return BadRequest(ModelState);
             }
 
-            if (account.Role == Role.Administrator && !User.IsInRole(nameof(Role.Administrator)))
+            if ((account.Role == Role.Administrator || account.Role == Role.Supervisor) && !User.IsInRole(nameof(Role.Administrator)))
             {
-                return StatusCode(403, "Administrative accounts may not be created by non-Administrative users.");
+                return StatusCode(403, "Neither administrative nor supervisory accounts may be created by non-Administrative users.");
             }
 
             var existingAccount = AccountRepository.GetAll(new AccountFilters() { Name = account.Name }).FirstOrDefault();

--- a/api/QCVOC.Api/Security/Controller/SecurityController.cs
+++ b/api/QCVOC.Api/Security/Controller/SecurityController.cs
@@ -405,14 +405,9 @@ namespace QCVOC.Api.Security.Controller
             }
             else if (User.IsInRole(nameof(Role.Administrator)))
             {
-                if (!string.IsNullOrWhiteSpace(account.Name))
+                if (AccountNameExistsExcludingId(account.Name, id))
                 {
-                    var conflictingAccounts = AccountRepository.GetAll(new AccountFilters() { Name = account.Name });
-
-                    if (conflictingAccounts.Any(a => a.Id != id))
-                    {
-                        return Conflict($"A user named '{account.Name}' already exists.");
-                    }
+                    return Conflict($"A user named '{account.Name}' already exists.");
                 }
 
                 accountRecord = new Account()

--- a/api/QCVOC.Api/Security/Controller/SecurityController.cs
+++ b/api/QCVOC.Api/Security/Controller/SecurityController.cs
@@ -538,7 +538,7 @@ namespace QCVOC.Api.Security.Controller
             }
         }
 
-        private bool AccountNameExistsExcludingId(string name, Guid id)
+        private bool AccountNameExistsExcludingId(string name, Guid id) 
         {
             return AccountRepository.GetAll(new AccountFilters() { Name = name }).Any(a => a.Id != id);
         }


### PR DESCRIPTION
Allow supervisors to change user names as well as reset passwords, but only for accounts in the User role.

Closes #38 