### PR TITLE
Add missing where clause placeholder in refresh token query

### DIFF
--- a/api/QCVOC.Api/Security/Data/Repository/RefreshTokenRepository.cs
+++ b/api/QCVOC.Api/Security/Data/Repository/RefreshTokenRepository.cs
@@ -139,6 +139,7 @@ namespace QCVOC.Api.Security.Data.Repository
                     issued AS Issued,
                     id AS Id
                 FROM refreshtokens
+                /**where**/
             ");
 
             builder.AddParameters(new


### PR DESCRIPTION
Fixes a bug causing a the result of a token refresh to contain credentials for a different account