### PR TITLE
Remove name field from password reset request payload

### DIFF
--- a/api/QCVOC.Api/Security/Controller/SecurityController.cs
+++ b/api/QCVOC.Api/Security/Controller/SecurityController.cs
@@ -369,9 +369,14 @@ namespace QCVOC.Api.Security.Controller
 
             if (User.GetId() == id && !User.IsInRole(nameof(Role.Administrator)))
             {
-                if (!string.IsNullOrWhiteSpace(account.Name) || account.Role != null)
+                if (!string.IsNullOrWhiteSpace(account.Name) && account.Name != accountToUpdate.Name)
                 {
-                    return StatusCode(403, "Users may not modify their own Account, except to change their password.");
+                    return StatusCode(403, "Users may not change their Account name.");
+                }
+
+                if (account.Role != null && account.Role != accountToUpdate.Role)
+                {
+                    return StatusCode(403, "Users may not change their Role.");
                 }
 
                 if (string.IsNullOrWhiteSpace(account.Password))

--- a/web/src/security/PasswordResetDialog.js
+++ b/web/src/security/PasswordResetDialog.js
@@ -109,16 +109,7 @@ class PasswordResetDialog extends Component {
 
             if (result.isValid) {
                 if (getCredentials().name === account.name) {
-                    let name = account.name;
-
-                    delete account.name;
-                    delete account.password2;
-                    
-                    this.execute(
-                        () => api.put('/v1/security/accounts/' + account.id, account), 
-                        'updateApi', 
-                        'Password for \'' + name + '\' successfully updated.'
-                    );
+                    this.updatePassword();
                 }
                 else {
                     this.setState({ confirmDialog: { open: true }});
@@ -128,13 +119,7 @@ class PasswordResetDialog extends Component {
     }
 
     handleResetConfirmation = () => {
-        let account = { ...this.state.account };
-
-        return this.execute(
-            () => api.put('/v1/security/accounts/' + account.id, account), 
-            'updateApi', 
-            'Password for \'' + account.name + '\' successfully updated.'
-        );
+        return this.updatePassword();
     }
 
     handleSnackbarClose = () => {
@@ -145,15 +130,21 @@ class PasswordResetDialog extends Component {
         this.setState({ confirmDialog: { open: false }});
     }
 
-    execute = (action, api, successMessage) => {
+    updatePassword = () => {
         return new Promise((resolve, reject) => {
-            this.setState({ [api]: { isExecuting: true }}, () => {
-                action(this.state.account)
+            this.setState({ updateApi: { isExecuting: true }}, () => {
+                let account = { ...this.state.account };
+                let name = account.name;
+        
+                delete account.name;
+                delete account.password2;
+
+                api.put('/v1/security/accounts/' + account.id, account)
                 .then(response => {
                     this.setState({
-                        [api]: { isExecuting: false, isErrored: false }
+                        updateApi: { isExecuting: false, isErrored: false }
                     }, () => {
-                        this.props.onClose(successMessage);
+                        this.props.onClose('Password for \'' + name + '\' successfully updated.');
                         resolve(response);
                     })
                 }, error => {
@@ -168,7 +159,7 @@ class PasswordResetDialog extends Component {
                     }
 
                     this.setState({ 
-                        [api]: { isExecuting: false, isErrored: true },
+                        updateApi: { isExecuting: false, isErrored: true },
                         snackbar: {
                             message: body,
                             open: true,

--- a/web/src/security/PasswordResetDialog.js
+++ b/web/src/security/PasswordResetDialog.js
@@ -105,16 +105,19 @@ class PasswordResetDialog extends Component {
 
     handleResetClick = () => {
         this.validate().then(result => {
-            let account = { ...this.state.account }
-            delete account.name;
-            delete account.password2;
+            let account = { ...this.state.account };
 
             if (result.isValid) {
                 if (getCredentials().name === account.name) {
+                    let name = account.name;
+
+                    delete account.name;
+                    delete account.password2;
+                    
                     this.execute(
                         () => api.put('/v1/security/accounts/' + account.id, account), 
                         'updateApi', 
-                        'Password for \'' + account.name + '\' successfully updated.'
+                        'Password for \'' + name + '\' successfully updated.'
                     );
                 }
                 else {

--- a/web/src/security/PasswordResetDialog.js
+++ b/web/src/security/PasswordResetDialog.js
@@ -106,6 +106,7 @@ class PasswordResetDialog extends Component {
     handleResetClick = () => {
         this.validate().then(result => {
             let account = { ...this.state.account }
+            delete account.name;
             delete account.password2;
 
             if (result.isValid) {


### PR DESCRIPTION
Only for accounts in the User role.  Update some checks on the back end to be more descriptive when the update rules are violated.

Closes #91 