### PR TITLE
Remove spaces and characters from phone number validation

### DIFF
--- a/api/QCVOC.Api/Veterans/Data/DTO/VeteranEnrollRequest.cs
+++ b/api/QCVOC.Api/Veterans/Data/DTO/VeteranEnrollRequest.cs
@@ -49,7 +49,7 @@ namespace QCVOC.Api.Veterans.Data.DTO
         ///     Gets or sets the primary phone number of the Veteran.
         /// </summary>
         [Required]
-        [Phone]
+        [RegularExpression(@"^[1-9][0-9]{9}$")]
         public string PrimaryPhone { get; set; }
 
         /// <summary>

--- a/api/QCVOC.Api/Veterans/Data/DTO/VeteranUpdateRequest.cs
+++ b/api/QCVOC.Api/Veterans/Data/DTO/VeteranUpdateRequest.cs
@@ -49,7 +49,7 @@ namespace QCVOC.Api.Veterans.Data.DTO
         ///     Gets or sets the primary phone number of the Veteran.
         /// </summary>
         [Required]
-        [Phone]
+        [RegularExpression(@"^[1-9][0-9]{9}$")]
         public string PrimaryPhone { get; set; }
 
         /// <summary>

--- a/web/src/util.js
+++ b/web/src/util.js
@@ -50,7 +50,7 @@ export const validateEmail = (email) => {
 
 export const validatePhoneNumber = (phoneNumber) => {
     // eslint-disable-next-line
-    var re = /\(\d{3}\) \d{3}-\d{4}/;
+    var re = /^[1-9][0-9]{9}$/;
     return re.test(phoneNumber);
 }
 

--- a/web/src/veterans/VeteranDialog.js
+++ b/web/src/veterans/VeteranDialog.js
@@ -227,7 +227,7 @@ class VeteranDialog extends Component {
             result.primaryPhone = 'The Primary Phone field is required.';
         }
         else if (!validatePhoneNumber(primaryPhone)) {
-            result.primaryPhone = 'Enter a valid phone number in the format (555) 555-5555.';
+            result.primaryPhone = 'Enter a valid phone number in the format \'555555555\'';
         }
 
         if ((email !== '' && email !== undefined) && !validateEmail(email)) {


### PR DESCRIPTION
Phone numbers must now be entered as a contiguous string consisting of 10 numbers, not starting with zero.

Closes #218 