### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/api/QCVOC.Api/QCVOC.Api.csproj
+++ b/api/QCVOC.Api/QCVOC.Api.csproj
@@ -28,18 +28,18 @@
     </AdditionalFiles>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="2.0.4" />
-    <PackageReference Include="Dapper" Version="1.50.5" />
-    <PackageReference Include="Dapper.SqlBuilder" Version="1.50.5" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="2.1.0" />
+    <PackageReference Include="Dapper" Version="1.60.6" />
+    <PackageReference Include="Dapper.SqlBuilder" Version="1.50.7" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
-    <PackageReference Include="NLog" Version="4.5.8" />
-    <PackageReference Include="Npgsql" Version="4.0.2" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
+    <PackageReference Include="NLog" Version="4.6.4" />
+    <PackageReference Include="Npgsql" Version="4.0.8" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi@jpdillingham, I found an issue in the QCVOC.Api.csproj:

Packages Amazon.Lambda.AspNetCoreServer v2.0.4, Dapper v1.50.5, Dapper.SqlBuilder v1.50.5, Microsoft.AspNetCore.App v2.1.0, Microsoft.AspNetCore.Authentication.JwtBearer v2.1.0, Microsoft.Extensions.Configuration.Json v2.1.0, Microsoft.VisualStudio.Web.CodeGeneration.Design v2.1.0, NLog v4.5.8, Npgsql v4.0.2 and StyleCop.Analyzers v1.0.2 transitively introduce 278  dependencies into QCVOC’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/QCVOC.html)), while Amazon.Lambda.AspNetCoreServer v2.1.0, Dapper v1.60.6, Dapper.SqlBuilder v1.50.7, Microsoft.AspNetCore.App v2.1.1, Microsoft.AspNetCore.Authentication.JwtBearer v2.1.2, Microsoft.Extensions.Configuration.Json v2.1.1, Microsoft.VisualStudio.Web.CodeGeneration.Design v2.1.1, NLog v4.6.4, Npgsql v4.0.8 and StyleCop.Analyzers v1.1.118 can only introduce 250 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/QCVOC_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose